### PR TITLE
Fix bug in is_palindrome.js

### DIFF
--- a/javascript-solutions/palindrome.js
+++ b/javascript-solutions/palindrome.js
@@ -16,14 +16,18 @@ const is_palindrome = (input_str) => {
   let l_pointer = 0;
   let r_pointer = processed_str.length - 1;
 
-  while (l_pointer !== r_pointer) {
+  while (l_pointer !== r_pointer && l_pointer < r_pointer) {
     if (processed_str[l_pointer] !== processed_str[r_pointer]) return false;
 
     l_pointer += 1;
-    r_pointer += 1;
-
-    return true;
+    r_pointer -= 1;
   }
+
+  return true;
 };
 
 console.log(is_palindrome("A man, a plan, a canal: Panama"));
+
+module.exports = {
+  is_palindrome
+}

--- a/javascript-solutions/palindrome.test.js
+++ b/javascript-solutions/palindrome.test.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const is_palindrome = require('./palindrome.js').is_palindrome;
+
+test('is_palindrome', async (t) => {
+    // These could be better written as "table-driven tests" since the structure of each test case is identical.
+    // But this might be more readable for students.
+
+    // inputs that are palindromes
+    await t.test('two identical letters', (t) => {
+        const input = 'aa';
+        const result = is_palindrome(input);
+        assert(result);
+    });
+
+    await t.test('aba', (t) => {
+        const input = 'aba';
+        const result = is_palindrome(input);
+        assert(result);
+    })
+
+    await t.test('abba', (t) => {
+        const input = 'abba';
+        const result = is_palindrome(input);
+        assert(result);
+    });
+
+    await t.test('A man, a plan, a canal: Panama', (t) => {
+        const input = 'A man, a plan, a canal: Panama';
+        const result = is_palindrome(input);
+        assert(result);
+    });
+
+    // inputs that are NOT palindromes
+    await t.test('two distinct letters', (t) => {
+        const input = 'ab';
+        const result = is_palindrome(input);
+        assert(!result);
+    });
+
+    await t.test('foobar', (t) => {
+        const input = 'foobar';
+        const result = is_palindrome(input);
+        assert(!result);
+    });
+
+    await t.test('foobarf', (t) => {
+        const input = 'foobarf';
+        const result = is_palindrome(input);
+        assert(!result);
+    })
+});


### PR DESCRIPTION
The current version returns `true` for some words that are not palindromes (e.g. `foobarf`). It also loops infinitely for inputs like `aa`.